### PR TITLE
Add robustness to part download failures due to 403 errors

### DIFF
--- a/onshape_urdf_exporter/__main__.py
+++ b/onshape_urdf_exporter/__main__.py
@@ -94,13 +94,23 @@ def main():
                 ).hexdigest()
             else:
                 shortend_configuration = part["configuration"]
-            stl = client.part_studio_stl_m(
-                part["documentId"],
-                part["documentMicroversion"],
-                part["elementId"],
-                part["partId"],
-                shortend_configuration,
-            )
+
+            try:
+                stl = client.part_studio_stl_m(
+                    part["documentId"],
+                    part["documentMicroversion"],
+                    part["elementId"],
+                    part["partId"],
+                    shortend_configuration,
+                )
+            except ConnectionRefusedError as e:
+                print(
+                    Fore.RED
+                    + f"Skipping part {part['name']}, because of connection error: {e}"
+                    + Style.RESET_ALL
+                )
+                return
+
             stl_file.write_bytes(stl)
             if config.simplify_stls:
                 simplify_stl(stl_file)

--- a/onshape_urdf_exporter/onshape_api/onshape.py
+++ b/onshape_urdf_exporter/onshape_api/onshape.py
@@ -254,9 +254,13 @@ class Onshape:
                 print(
                     "HINT: Check that your access rights are correct, and that the clock on your computer is set correctly"
                 )
-            exit()
+                raise ConnectionRefusedError(
+                    "HINT: Check that your access rights are correct, and that the clock on your computer is set correctly"
+                )
             if self._logging:
                 utils.log("request failed, details: " + res.text, level=1)
+            exit()
+
         else:
             if self._logging:
                 utils.log("request succeeded, details: " + res.text)


### PR DESCRIPTION
It seems like some parts just consistently fail to download due to access rights errors. I think this leads to a loop where andrew or gabby have to 

1. run exporter
2. see a 403 failure on part X
3. go on onshape and "suppress" part X
4. go back to step 1

So this helps remove that loop, and speeds up the process! Root cause for 403 errors is unknown though :/